### PR TITLE
fix issue with edge triggered(EPOLLET) read monitoring(EPOLLIN) that …

### DIFF
--- a/src/microhttpd/connection.c
+++ b/src/microhttpd/connection.c
@@ -2814,7 +2814,7 @@ MHD_update_last_activity_ (struct MHD_Connection *connection)
  *
  * @param connection connection to handle
  */
-void
+ssize_t
 MHD_connection_handle_read (struct MHD_Connection *connection)
 {
   ssize_t bytes_read;
@@ -2851,7 +2851,7 @@ MHD_connection_handle_read (struct MHD_Connection *connection)
   if (bytes_read < 0)
   {
     if (MHD_ERR_AGAIN_ == bytes_read)
-      return;     /* No new data to process. */
+      return bytes_read;     /* No new data to process. */
     if (MHD_ERR_CONNRESET_ == bytes_read)
     {
       CONNECTION_CLOSE_ERROR (connection,
@@ -2859,7 +2859,7 @@ MHD_connection_handle_read (struct MHD_Connection *connection)
                               NULL :
                               _ (
                                 "Socket disconnected while reading request."));
-      return;
+      return bytes_read;
     }
 
 #ifdef HAVE_MESSAGES
@@ -2871,7 +2871,7 @@ MHD_connection_handle_read (struct MHD_Connection *connection)
 #endif
     CONNECTION_CLOSE_ERROR (connection,
                             NULL);
-    return;
+    return bytes_read;
   }
 
   if (0 == bytes_read)
@@ -2879,7 +2879,7 @@ MHD_connection_handle_read (struct MHD_Connection *connection)
     connection->read_closed = true;
     MHD_connection_close_ (connection,
                            MHD_REQUEST_TERMINATED_CLIENT_ABORT);
-    return;
+    return bytes_read;
   }
   connection->read_buffer_offset += bytes_read;
   MHD_update_last_activity_ (connection);
@@ -2906,13 +2906,13 @@ MHD_connection_handle_read (struct MHD_Connection *connection)
       MHD_connection_close_ (connection,
                              MHD_REQUEST_TERMINATED_READ_ERROR);
     }
-    return;
+    return bytes_read;
   case MHD_CONNECTION_CLOSED:
-    return;
+    return bytes_read;
 #ifdef UPGRADE_SUPPORT
   case MHD_CONNECTION_UPGRADE:
     mhd_assert (0);
-    return;
+    return bytes_read;
 #endif /* UPGRADE_SUPPORT */
   default:
     /* shrink read buffer to how much is actually used */
@@ -2922,7 +2922,7 @@ MHD_connection_handle_read (struct MHD_Connection *connection)
                          connection->read_buffer_offset);
     break;
   }
-  return;
+  return bytes_read;
 }
 
 

--- a/src/microhttpd/connection.h
+++ b/src/microhttpd/connection.h
@@ -93,8 +93,10 @@ MHD_set_http_callbacks_ (struct MHD_Connection *connection);
  * call this function to handle reads.
  *
  * @param connection connection to handle
+ * @return number of bytes read from the connection.
+ *         or negative error code if any error occurred
  */
-void
+ssize_t
 MHD_connection_handle_read (struct MHD_Connection *connection);
 
 

--- a/src/microhttpd/daemon.c
+++ b/src/microhttpd/daemon.c
@@ -1209,8 +1209,13 @@ call_handlers (struct MHD_Connection *con,
     if ( (MHD_EVENT_LOOP_INFO_READ == con->event_loop_info) &&
          read_ready)
     {
-      MHD_connection_handle_read (con);
-      ret = MHD_connection_handle_idle (con);
+      do
+      {
+        ssize_t bytes_read = MHD_connection_handle_read (con);
+        ret = MHD_connection_handle_idle (con);
+        if (bytes_read <= 0)
+          break;
+      } while (true);
       states_info_processed = true;
     }
     /* No need to check value of 'ret' here as closed connection


### PR DESCRIPTION
Hi, 

This is for fixing an issue that we encountered when using libmicrohttpd with external epoll mode.

When client request data size is bigger than that of connection read buffer(default or configured size), data is not fully read out of socket OS read buffer in a single round of processing, and residual data left unread will not trigger next epoll_wait() to return, as libmicrohttpd is using EPOLLET(edge-triggered) when adding client socket to epoll instance.

In this case, the `call_handlers()` function should try to read all available request data from socket before finishing this round of `read_ready=true` handling.

We simply have tried to loop over the `MHD_connection_handle_read()` and `MHD_connection_handle_idle()` to read and process as much data as possible in single round of read-ready processing, and this solves the issue.

Please feel free to review and let us know if anything is wrong in our pull request.

Thanks and regards

Nan