### PR TITLE
Fix threaded example HTML-code

### DIFF
--- a/src/examples/websocket_threaded_example.c
+++ b/src/examples/websocket_threaded_example.c
@@ -36,7 +36,7 @@
   "<title>WebSocket chat</title>\n"                                           \
   "<script>\n"                                                                \
   "document.addEventListener('DOMContentLoaded', function() {\n"              \
-  "  const ws = new WebSocket('ws:// ' + window.location.host);\n"        /*  \
+  "  const ws = new WebSocket('ws://' + window.location.host);\n"             \
   "  const btn = document.getElementById('send');\n"                          \
   "  const msg = document.getElementById('msg');\n"                           \
   "  const log = document.getElementById('log');\n"                           \
@@ -69,7 +69,7 @@
   "<input type='button' id='send' value='Send' /><br /><br />\n"              \
   "<textarea id='log' rows='20' cols='28'></textarea>\n"                      \
   "</body>\n"                                                                 \
-  "</html>"                                                               */
+  "</html>"
 #define BAD_REQUEST_PAGE                                                      \
   "<html>\n"                                                                  \
   "<head>\n"                                                                  \


### PR DESCRIPTION
Uncomment HTML-code in websocket threaded example, remove whitespace in websocket URL (required by chromium).