### PR TITLE
websocket_threaded_example: fix websocket url string

### DIFF
--- a/src/examples/websocket_threaded_example.c
+++ b/src/examples/websocket_threaded_example.c
@@ -39,7 +39,7 @@
   "<title>WebSocket chat</title>\n"                                           \
   "<script>\n"                                                                \
   "document.addEventListener('DOMContentLoaded', function() {\n"              \
-  "  const ws = new WebSocket('ws:/" "/ ' + window.location.host);\n"         \
+  "  const ws = new WebSocket('ws:/" "/' + window.location.host);\n"         \
   "  const btn = document.getElementById('send');\n"                          \
   "  const msg = document.getElementById('msg');\n"                           \
   "  const log = document.getElementById('log');\n"                           \


### PR DESCRIPTION
Remove extra space character from websocket url string.

The code was broken by beb7fa82 ("fix transmission stall issue with upgraded TLS connections reported by Nguyen Xuan Viet on the mailinglist").