### PR TITLE
src/examples/demo{,_https}: fix response buffer overwriting

### DIFF
--- a/src/examples/demo.c
+++ b/src/examples/demo.c
@@ -413,7 +413,7 @@ update_directory (void)
     update_cached_response (NULL);
     return;
   }
-  memcpy (rdc.buf, INDEX_PAGE_FOOTER, len);
+  memcpy (&rdc.buf[rdc.off], INDEX_PAGE_FOOTER, len);
   rdc.off += len;
   initial_allocation = rdc.buf_len; /* remember for next time */
   response =

--- a/src/examples/demo_https.c
+++ b/src/examples/demo_https.c
@@ -415,7 +415,7 @@ update_directory (void)
     update_cached_response (NULL);
     return;
   }
-  memcpy (rdc.buf, INDEX_PAGE_FOOTER, len);
+  memcpy (&rdc.buf[rdc.off], INDEX_PAGE_FOOTER, len);
   rdc.off += len;
   initial_allocation = rdc.buf_len; /* remember for next time */
   response =


### PR DESCRIPTION
Due to an unaccounted offset, the header was overwritten by the footer. Adding address offset when copying string.

The code was broken by 5821a7f3 ("src/examples/demo{,_https}: added some error checking, fixed compiler warnings").